### PR TITLE
Debug: Adicionar logging detalhado para variáveis de ambiente de aute…

### DIFF
--- a/libs/controllers/auth.py
+++ b/libs/controllers/auth.py
@@ -20,18 +20,24 @@ def authenticate_user(username, password, selected_usina_nome, usinas_config):
     Autentica o usuário com base no nome de usuário, senha e usina selecionada.
     Retorna (True, usina_obj) se autenticado, senão (False, None).
     """
-    env_user = os.getenv('DASH_USER')
-    env_pass_hash_stored = os.getenv('DASH_PASS_HASH')
-    env_salt = os.getenv('DASH_SALT')
+    logger.info(f"Tentando ler variáveis de ambiente para autenticação:") # Added
+    env_user_value = os.getenv('DASH_USER') # Changed variable name
+    env_pass_hash_stored_value = os.getenv('DASH_PASS_HASH') # Changed variable name
+    env_salt_value = os.getenv('DASH_SALT') # Changed variable name
 
-    if not env_user or not env_pass_hash_stored or not env_salt:
+    logger.info(f"Valor de DASH_USER: '{env_user_value}' (Tipo: {type(env_user_value)})") # Added
+    logger.info(f"Valor de DASH_PASS_HASH: '{env_pass_hash_stored_value}' (Tipo: {type(env_pass_hash_stored_value)})") # Added
+    logger.info(f"Valor de DASH_SALT: '{env_salt_value}' (Tipo: {type(env_salt_value)})") # Added
+
+    if not env_user_value or not env_pass_hash_stored_value or not env_salt_value: # Logic uses new variable names
         logger.error("Credenciais do dashboard (DASH_USER, DASH_PASS_HASH, DASH_SALT) não estão completamente configuradas no .env.")
         return False, None
 
-    # Calcular o hash da senha fornecida
-    password_hashed = hashlib.sha256((env_salt + password).encode('utf-8')).hexdigest()
+    # Calcular o hash da senha fornecida usando env_salt_value
+    password_hashed = hashlib.sha256((env_salt_value + password).encode('utf-8')).hexdigest()
 
-    if username == env_user and password_hashed == env_pass_hash_stored:
+    # Comparar usando env_user_value e env_pass_hash_stored_value
+    if username == env_user_value and password_hashed == env_pass_hash_stored_value:
         if selected_usina_nome in usinas_config:
             usina_obj = usinas_config[selected_usina_nome]
             logger.info(f"Usuário '{username}' autenticado com sucesso para a usina '{selected_usina_nome}'.")


### PR DESCRIPTION
…nticação

Esta alteração adiciona logs mais detalhados na função `authenticate_user` em `libs/controllers/auth.py`. O objetivo é registrar os valores crus obtidos de `os.getenv()` para as variáveis `DASH_USER`, `DASH_PASS_HASH`, e `DASH_SALT`.

Isso ajudará a diagnosticar problemas de configuração de variáveis de ambiente em plataformas de hospedagem como o Railway, especificamente para identificar quais variáveis podem não estar sendo lidas corretamente.